### PR TITLE
[16.0][IMP] account_avatax*: Improved tax recalculation in certain states

### DIFF
--- a/account_avatax_oca/__manifest__.py
+++ b/account_avatax_oca/__manifest__.py
@@ -25,6 +25,7 @@
         "views/account_move_view.xml",
         "views/account_tax_view.xml",
         "views/account_fiscal_position_view.xml",
+        "views/res_country_state_view.xml",
     ],
     "demo": ["demo/avatax_demo.xml"],
     "images": ["static/description/avatax_icon.png"],

--- a/account_avatax_oca/models/__init__.py
+++ b/account_avatax_oca/models/__init__.py
@@ -6,3 +6,4 @@ from . import account_fiscal_position
 from . import account_tax
 from . import res_company
 from . import avatax_rest_api
+from . import res_country_state

--- a/account_avatax_oca/models/account_move.py
+++ b/account_avatax_oca/models/account_move.py
@@ -200,6 +200,7 @@ class AccountMove(models.Model):
         doc_type = self._get_avatax_doc_type(commit=commit)
         tax_date = self.get_origin_tax_date() or self.invoice_date
         taxable_lines = self._avatax_prepare_lines(doc_type)
+        shipping_address = self.tax_address_id or self.partner_id
         tax_result = avatax_config.create_transaction(
             self.invoice_date or fields.Date.today(),
             self.name,
@@ -210,7 +211,7 @@ class AccountMove(models.Model):
                 else self.partner_id
             ),
             self.warehouse_id.partner_id or self.company_id.partner_id,
-            self.tax_address_id or self.partner_id,
+            shipping_address,
             taxable_lines,
             self.user_id,
             self.exemption_code or None,
@@ -243,17 +244,20 @@ class AccountMove(models.Model):
             Tax = self.env["account.tax"]
             tax_result_lines = {int(x["lineNumber"]): x for x in tax_result["lines"]}
             taxes_to_set = {}
+            is_recalculate_tax_rate = shipping_address.state_id.recalculate_tax_rate
             for line in self.invoice_line_ids:
                 tax_result_line = tax_result_lines.get(line.id)
                 if tax_result_line:
-                    # rate = tax_result_line.get("rate", 0.0)
-                    tax_calculation = 0.0
-                    if tax_result_line["taxableAmount"]:
-                        tax_calculation = (
-                            tax_result_line["taxCalculated"]
-                            / tax_result_line["taxableAmount"]
-                        )
-                    rate = round(tax_calculation * 100, 4)
+                    if not is_recalculate_tax_rate:
+                        rate = tax_result_line["rate"]
+                    else:
+                        tax_calculation = 0.0
+                        if tax_result_line["taxableAmount"]:
+                            tax_calculation = (
+                                tax_result_line["taxCalculated"]
+                                / tax_result_line["taxableAmount"]
+                            )
+                        rate = round(tax_calculation * 100, 4)
                     tax = Tax.get_avalara_tax(rate, doc_type)
                     tax, line = self.update_tax_details(tax, line, tax_result_line)
                     if tax and tax not in line.tax_ids:

--- a/account_avatax_oca/models/res_country_state.py
+++ b/account_avatax_oca/models/res_country_state.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class CountryState(models.Model):
+    _inherit = "res.country.state"
+
+    recalculate_tax_rate = fields.Boolean(default=False)

--- a/account_avatax_oca/views/res_country_state_view.xml
+++ b/account_avatax_oca/views/res_country_state_view.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="view_country_state_tree" model="ir.ui.view">
+        <field name="name">res.country.state.tree</field>
+        <field name="model">res.country.state</field>
+        <field name="inherit_id" ref="base.view_country_state_tree" />
+        <field name="arch" type="xml">
+            <tree position="inside">
+                <field name="recalculate_tax_rate" widget="boolean_toggle" />
+            </tree>
+        </field>
+    </record>
+</odoo>

--- a/account_avatax_sale_oca/models/sale_order.py
+++ b/account_avatax_sale_oca/models/sale_order.py
@@ -184,13 +184,14 @@ class SaleOrder(models.Model):
         if avatax_config.use_partner_invoice_id:
             partner = self.partner_invoice_id
         taxable_lines = self._avatax_prepare_lines(self.order_line)
+        shipping_address = self.tax_address_id or self.partner_id
         tax_result = avatax_config.create_transaction(
             self.date_order,
             self.name,
             doc_type,
             partner,
             self.warehouse_id.partner_id or self.company_id.partner_id,
-            self.tax_address_id or self.partner_id,
+            shipping_address,
             taxable_lines,
             self.user_id,
             self.exemption_code or None,
@@ -199,20 +200,23 @@ class SaleOrder(models.Model):
             log_to_record=self,
         )
         tax_result_lines = {int(x["lineNumber"]): x for x in tax_result["lines"]}
+        is_recalculate_tax_rate = shipping_address.state_id.recalculate_tax_rate
         for line in self.order_line:
             tax_result_line = tax_result_lines.get(line.id)
             if tax_result_line:
                 # Should we check the rate with the tax amount?
                 # tax_amount = tax_result_line["taxCalculated"]
                 # rate = round(tax_amount / line.price_subtotal * 100, 2)
-                # rate = tax_result_line["rate"]
-                tax_calculation = 0.0
-                if tax_result_line["taxableAmount"]:
-                    tax_calculation = (
-                        tax_result_line["taxCalculated"]
-                        / tax_result_line["taxableAmount"]
-                    )
-                rate = round(tax_calculation * 100, 4)
+                if not is_recalculate_tax_rate:
+                    rate = tax_result_line["rate"]
+                else:
+                    tax_calculation = 0.0
+                    if tax_result_line["taxableAmount"]:
+                        tax_calculation = (
+                            tax_result_line["taxCalculated"]
+                            / tax_result_line["taxableAmount"]
+                        )
+                    rate = round(tax_calculation * 100, 4)
                 tax = Tax.get_avalara_tax(rate, doc_type)
                 tax, line = self.update_tax_details(tax, line, tax_result_line)
                 if tax not in line.tax_id:


### PR DESCRIPTION
In certain jurisdictions like **Tennessee (TN)**, tax lines can involve split taxable amounts that require recalculating the effective tax rate, as demonstrated in this PR `https://github.com/OCA/account-fiscal-rule/pull/371`

However, applying this recalculation logic systematically for all states has the side effect of creating many unwanted taxes in odoo.

To address this issues, this PR introduces a new optional field: `recalculate_tax_rate` on the state model. This allows users to explicitly enable tax rate recalculation only for specific states, like TN, without impacting other regions.