### PR TITLE
[16.0][IMP] account_avatax_[sale]_oca: support multiple taxes appearing on each line instead of one

### DIFF
--- a/account_avatax_oca/hooks.py
+++ b/account_avatax_oca/hooks.py
@@ -100,3 +100,31 @@ def post_load_hook():  # noqa: C901
     if not hasattr(AccountMoveLine, "_compute_all_tax_origin"):
         AccountMoveLine._compute_all_tax_origin = AccountMoveLine._compute_all_tax
     AccountMoveLine._compute_all_tax = _compute_all_tax_new
+
+    @api.depends("quantity", "discount", "price_unit", "tax_ids", "currency_id")
+    def _compute_totals_new(self):
+        for line in self:
+            if line.display_type != "product":
+                line.price_total = line.price_subtotal = False
+            # Compute 'price_subtotal'.
+            line_discount_price_unit = line.price_unit * (1 - (line.discount / 100.0))
+            subtotal = line.quantity * line_discount_price_unit
+
+            # Compute 'price_total'.
+            if line.tax_ids:
+                taxes_res = line.tax_ids.with_context(current_aml=line.id).compute_all(
+                    line_discount_price_unit,
+                    quantity=line.quantity,
+                    currency=line.currency_id,
+                    product=line.product_id,
+                    partner=line.partner_id,
+                    is_refund=line.is_refund,
+                )
+                line.price_subtotal = taxes_res["total_excluded"]
+                line.price_total = taxes_res["total_included"]
+            else:
+                line.price_total = line.price_subtotal = subtotal
+
+    if not hasattr(AccountMoveLine, "_compute_totals_origin"):
+        AccountMoveLine._compute_totals_origin = AccountMoveLine._compute_totals
+    AccountMoveLine._compute_totals = _compute_totals_new

--- a/account_avatax_oca/models/account_move.py
+++ b/account_avatax_oca/models/account_move.py
@@ -238,17 +238,18 @@ class AccountMove(models.Model):
             avatax_config.unvoid_transaction(self.name, doc_type)
             avatax_config.commit_transaction(self.name, doc_type)
             return tax_result
-
-        if self.state == "draft":
-            Tax = self.env["account.tax"]
-            tax_result_lines = {int(x["lineNumber"]): x for x in tax_result["lines"]}
-            taxes_to_set = {}
-            for line in self.invoice_line_ids:
-                tax_result_line = tax_result_lines.get(line.id)
-                if not tax_result_line:
-                    continue
+        if self.state != "draft":
+            return tax_result
+        Tax = self.env["account.tax"]
+        tax_result_lines = {int(x["lineNumber"]): x for x in tax_result["lines"]}
+        taxes_to_set = {}
+        for line in self.invoice_line_ids:
+            tax_result_line = tax_result_lines.get(line.id)
+            if not tax_result_line:
+                continue
+            new_taxes = Tax
+            if avatax_config.breakdown_all_taxes:
                 details = tax_result_line["details"]
-                new_taxes = Tax
                 for detail in details:
                     fixed = detail.get("unitOfBasis") == "FlatAmount"
                     rate = detail["rate"] if fixed else detail["rate"] * 100
@@ -260,43 +261,47 @@ class AccountMove(models.Model):
                     tax = Tax.get_avalara_tax(rate, doc_type, tax_name=tax_name_display)
                     tax, line = self.update_tax_details(tax, line, tax_result_line)
                     new_taxes |= tax
-                if new_taxes and new_taxes not in line.tax_ids:
-                    line_taxes = line.tax_ids.filtered(lambda x: not x.is_avatax)
-                    taxes_to_set[line.id] = line_taxes | new_taxes
-            self.with_context(check_move_validity=False).avatax_amount = tax_result[
-                "totalTax"
-            ]
-            container = {"records": self}
-
-            # Set Taxes on lines in a way that properly triggers onchanges
-            # This same approach is also used by the official account_taxcloud connector
-            with self.with_context(
-                avatax_invoice=self, check_move_validity=False
-            )._sync_dynamic_lines(container), self.line_ids.mapped(
-                "move_id"
-            )._check_balanced(
-                container
-            ):
-                for line_id in taxes_to_set.keys():
-                    line = self.invoice_line_ids.filtered(lambda x: x.id == line_id)
-                    line.write({"tax_ids": [(6, 0, [])]})
-                    line.with_context(
-                        avatax_invoice=self, check_move_validity=False
-                    ).write({"tax_ids": taxes_to_set.get(line_id).ids})
-            # After taxes are changed is needed to force compute taxes again, in 16 version
-            # change of tax doesn't trigger compute of taxes on header for unknown reason
-            self._compute_amount()
-            if float_compare(
-                self.amount_untaxed + max(self.amount_tax, abs(self.avatax_amount)),
-                self.amount_residual,
-                precision_rounding=self.currency_id.rounding or 0.001,
-            ):
-                taxes_data = {
-                    iline.id: iline.tax_ids for iline in self.invoice_line_ids
-                }
-                self.invoice_line_ids.write({"tax_ids": [(6, 0, [])]})
-                for line in self.invoice_line_ids:
-                    line.write({"tax_ids": taxes_data[line.id].ids})
+            else:
+                taxable_amt = tax_result_line.get("taxableAmount", 0.0)
+                tax_calc_amt = tax_result_line.get("taxCalculated") or 0.0
+                if taxable_amt:
+                    rate = round((tax_calc_amt / taxable_amt) * 100, 4)
+                    tax = Tax.get_avalara_tax(rate, doc_type)
+                    new_taxes |= tax
+            if new_taxes and new_taxes not in line.tax_ids:
+                line_taxes = line.tax_ids.filtered(lambda x: not x.is_avatax)
+                taxes_to_set[line.id] = line_taxes | new_taxes
+        self.with_context(check_move_validity=False).avatax_amount = tax_result[
+            "totalTax"
+        ]
+        container = {"records": self}
+        # Set Taxes on lines in a way that properly triggers onchanges
+        # This same approach is also used by the official account_taxcloud connector
+        with self.with_context(
+            avatax_invoice=self, check_move_validity=False
+        )._sync_dynamic_lines(container), self.line_ids.mapped(
+            "move_id"
+        )._check_balanced(
+            container
+        ):
+            for line_id, taxes in taxes_to_set.items():
+                line = self.invoice_line_ids.filtered(lambda l: l.id == line_id)
+                line.write({"tax_ids": [(6, 0, [])]})
+                line.with_context(avatax_invoice=self, check_move_validity=False).write(
+                    {"tax_ids": taxes.ids}
+                )
+        # After taxes are changed is needed to force compute taxes again, in 16 version
+        # change of tax doesn't trigger compute of taxes on header for unknown reason
+        self._compute_amount()
+        if float_compare(
+            self.amount_untaxed + max(self.amount_tax, abs(self.avatax_amount)),
+            self.amount_residual,
+            precision_rounding=self.currency_id.rounding or 0.001,
+        ):
+            taxes_data = {iline.id: iline.tax_ids for iline in self.invoice_line_ids}
+            self.invoice_line_ids.write({"tax_ids": [(6, 0, [])]})
+            for line in self.invoice_line_ids:
+                line.write({"tax_ids": taxes_data[line.id].ids})
         return tax_result
 
     # Same as v13

--- a/account_avatax_oca/models/account_move.py
+++ b/account_avatax_oca/models/account_move.py
@@ -245,21 +245,24 @@ class AccountMove(models.Model):
             taxes_to_set = {}
             for line in self.invoice_line_ids:
                 tax_result_line = tax_result_lines.get(line.id)
-                if tax_result_line:
-                    # rate = tax_result_line.get("rate", 0.0)
-                    tax_calculation = 0.0
-                    if tax_result_line["taxableAmount"]:
-                        tax_calculation = (
-                            tax_result_line["taxCalculated"]
-                            / tax_result_line["taxableAmount"]
-                        )
-                    rate = round(tax_calculation * 100, 4)
-                    tax = Tax.get_avalara_tax(rate, doc_type)
+                if not tax_result_line:
+                    continue
+                details = tax_result_line["details"]
+                new_taxes = Tax
+                for detail in details:
+                    fixed = detail.get("unitOfBasis") == "FlatAmount"
+                    rate = detail["rate"] if fixed else detail["rate"] * 100
+                    tax_group_name = detail["taxName"].removesuffix(" TAX")
+                    tax_name_display = "%s %s" % (
+                        tax_group_name,
+                        ("$ %.4g" if fixed else "%.4g%%") % round(rate, 4),
+                    )
+                    tax = Tax.get_avalara_tax(rate, doc_type, tax_name=tax_name_display)
                     tax, line = self.update_tax_details(tax, line, tax_result_line)
-                    if tax and tax not in line.tax_ids:
-                        line_taxes = line.tax_ids.filtered(lambda x: not x.is_avatax)
-                        taxes_to_set[line.id] = line_taxes | tax
-                    line.avatax_amt_line = tax_result_line["tax"]
+                    new_taxes |= tax
+                if new_taxes and new_taxes not in line.tax_ids:
+                    line_taxes = line.tax_ids.filtered(lambda x: not x.is_avatax)
+                    taxes_to_set[line.id] = line_taxes | new_taxes
             self.with_context(check_move_validity=False).avatax_amount = tax_result[
                 "totalTax"
             ]

--- a/account_avatax_oca/models/account_tax.py
+++ b/account_avatax_oca/models/account_tax.py
@@ -126,7 +126,6 @@ class AccountTax(models.Model):
                         current_aml = line
                         break
             if avatax_amount is None:
-                avatax_amount = 0.0
                 raise exceptions.UserError(
                     _(
                         "Incorrect retrieval of Avatax amount for Invoice %(avatax_invoice)s:"
@@ -151,23 +150,14 @@ class AccountTax(models.Model):
             ]
             if not relevant_tax_ids:
                 return res
-            if not self:
-                company = self.env.company
-            else:
-                company = self[0].company_id
-            if not currency:
-                currency = company.currency_id
-            prec = currency.rounding
-            round_tax = (
-                False
-                if company.tax_calculation_rounding_method == "round_globally"
-                else True
-            )
+            company = self.env.company if not self else self[0].company_id
+            currency = currency or company.currency_id
+            precision = currency.rounding
+            round_tax = company.tax_calculation_rounding_method != "round_globally"
             if "round" in self.env.context:
                 round_tax = bool(self.env.context["round"])
-
             if not round_tax:
-                prec *= 1e-5
+                precision *= 1e-5
             base = price_unit * quantity
             if self._context.get("round_base", True):
                 base = currency.round(base)
@@ -176,24 +166,34 @@ class AccountTax(models.Model):
                 sign = -1 if fixed_multiplicator < 0 else 1
             elif base < 0:
                 sign = -1
-            for detail in line_result.get("details", []):
-                fixed = detail.get("unitOfBasis") == "FlatAmount"
-                rate = detail["rate"] if fixed else detail["rate"] * 100
-                tax_group_name = detail.get("taxName", "").removesuffix(" TAX")
-                tax_name_display = "%s %s" % (
-                    tax_group_name,
-                    ("$ %.4g" if fixed else "%.4g%%") % round(rate, 4),
-                )
-                tax = self.get_avalara_tax(rate, doc_type, tax_name=tax_name_display)
-                for tax_item in relevant_tax_ids:
-                    if tax_item["id"] == tax.id:
-                        tax_item["amount"] = (
-                            float_round(detail["tax"], precision_rounding=prec) * sign
-                        )
-                        tax_item["base"] = float_round(
-                            sign * detail["taxableAmount"], precision_rounding=prec
-                        )
-            res["total_included"] = total_excluded + sum(
-                t["amount"] for t in res["taxes"]
-            )
+            avatax_config = avatax_invoice.company_id.get_avatax_config_company()
+            if not avatax_config:
+                return res
+            if not avatax_config.breakdown_all_taxes:
+                for tax_item in res["taxes"]:
+                    if tax_item["amount"] != 0:
+                        tax_item["amount"] = avatax_amount
+            else:
+                for detail in line_result.get("details", []):
+                    fixed = detail.get("unitOfBasis") == "FlatAmount"
+                    rate = detail["rate"] if fixed else detail["rate"] * 100
+                    tax_group_name = detail.get("taxName", "").removesuffix(" TAX")
+                    tax_name_display = "%s %s" % (
+                        tax_group_name,
+                        ("$ %.4g" if fixed else "%.4g%%") % round(rate, 4),
+                    )
+                    tax = self.get_avalara_tax(
+                        rate, doc_type, tax_name=tax_name_display
+                    )
+                    for tax_item in relevant_tax_ids:
+                        if tax_item["id"] == tax.id:
+                            tax_item["amount"] = (
+                                float_round(detail["tax"], precision_rounding=precision)
+                                * sign
+                            )
+                            tax_item["base"] = float_round(
+                                sign * detail["taxableAmount"],
+                                precision_rounding=precision,
+                            )
+            res["total_included"] = total_excluded + avatax_amount
         return res

--- a/account_avatax_oca/models/account_tax.py
+++ b/account_avatax_oca/models/account_tax.py
@@ -1,7 +1,8 @@
+import ast
 from math import copysign
 
 from odoo import _, api, exceptions, fields, models
-from odoo.tools.float_utils import float_compare
+from odoo.tools.float_utils import float_compare, float_round
 
 
 class AccountTax(models.Model):
@@ -12,8 +13,8 @@ class AccountTax(models.Model):
     is_avatax = fields.Boolean()
 
     @api.model
-    def _get_avalara_tax_domain(self, tax_rate, doc_type):
-        return [
+    def _get_avalara_tax_domain(self, tax_rate, doc_type, tax_name=None):
+        domain = [
             ("amount", "=", tax_rate),
             ("is_avatax", "=", True),
             (
@@ -22,19 +23,22 @@ class AccountTax(models.Model):
                 self.env.company.id,
             ),
         ]
+        if tax_name:
+            domain.append(("name", "=", tax_name))
+        return domain
 
     @api.model
     def _get_avalara_tax_name(self, tax_rate, doc_type=None):
         return _("{}%*").format(str(tax_rate))
 
     @api.model
-    def get_avalara_tax(self, tax_rate, doc_type):
-        domain = self._get_avalara_tax_domain(tax_rate, doc_type)
+    def get_avalara_tax(self, tax_rate, doc_type, tax_name=None):
+        domain = self._get_avalara_tax_domain(tax_rate, doc_type, tax_name)
         tax = self.with_context(active_test=False).search(domain, limit=1)
         if tax and not tax.active:
             tax.active = True
         if not tax:
-            domain = self._get_avalara_tax_domain(0, doc_type)
+            domain = self._get_avalara_tax_domain(0, doc_type, "")
             tax_template = self.search(domain, limit=1)
             if not tax_template:
                 raise exceptions.UserError(
@@ -45,13 +49,16 @@ class AccountTax(models.Model):
             # check the data for your existing Avatax taxes.
             vals = {
                 "amount": tax_rate,
-                "name": self._get_avalara_tax_name(tax_rate, doc_type),
+                "name": tax_name
+                if tax_name
+                else self._get_avalara_tax_name(tax_rate, doc_type),
             }
             tax = tax_template.sudo().copy(default=vals)
             # Odoo core does not use the name set in default dict
             tax.name = vals.get("name")
         return tax
 
+    # flake8: noqa: C901
     def compute_all(
         self,
         price_unit,
@@ -78,11 +85,11 @@ class AccountTax(models.Model):
             partner,
             is_refund,
             handle_price_include,
-            include_caba_tags,
-            fixed_multiplicator,
+            include_caba_tags=include_caba_tags,
+            fixed_multiplicator=fixed_multiplicator,
         )
         avatax_invoice = self.env.context.get("avatax_invoice")
-        current_aml = False
+        current_aml = self.env["account.move.line"]
         if "current_aml" in self.env.context:
             current_aml = self.env["account.move.line"].browse(
                 self.env.context.get("current_aml")
@@ -92,15 +99,17 @@ class AccountTax(models.Model):
                 and current_aml.account_type != "asset_receivable"
             ):
                 avatax_invoice = False
+        if not avatax_invoice and current_aml:
+            avatax_invoice = current_aml.move_id
         if avatax_invoice:
             # Find the Avatax amount in the invoice Lines
             # Looks up the line for the current product, price_unit, and quantity
             # Note that the price_unit used must consider discount
-            base = res["total_excluded"]
+            total_excluded = res["total_excluded"]
             digits = 6
             avatax_amount = None
             if current_aml:
-                avatax_amount = copysign(current_aml.avatax_amt_line, base)
+                avatax_amount = copysign(current_aml.avatax_amt_line, total_excluded)
             else:
                 for line in avatax_invoice.invoice_line_ids:
                     price_unit = line.currency_id._convert(
@@ -113,7 +122,8 @@ class AccountTax(models.Model):
                         line.product_id == product
                         and float_compare(line.quantity, quantity, digits) == 0
                     ):
-                        avatax_amount = copysign(line.avatax_amt_line, base)
+                        avatax_amount = copysign(line.avatax_amt_line, total_excluded)
+                        current_aml = line
                         break
             if avatax_amount is None:
                 avatax_amount = 0.0
@@ -124,8 +134,66 @@ class AccountTax(models.Model):
                         " , quantity %(quantity)f"
                     )
                 )
-            for tax_item in res["taxes"]:
-                if tax_item["amount"] != 0:
-                    tax_item["amount"] = avatax_amount
-            res["total_included"] = base + avatax_amount
+            response = ast.literal_eval(avatax_invoice.avatax_response_log or "{}")
+            response_lines = {
+                int(l["lineNumber"]): l for l in response.get("lines", [])
+            }
+            doc_type = avatax_invoice._get_avatax_doc_type()
+            avatax_ids = self.search([("is_avatax", "=", True)]).ids
+            line = current_aml
+            line_result = response_lines.get(line.id)
+            if not line_result:
+                return res
+            relevant_tax_ids = [
+                x
+                for x in res["taxes"]
+                if x["id"] in line.tax_ids.ids and x["id"] in avatax_ids
+            ]
+            if not relevant_tax_ids:
+                return res
+            if not self:
+                company = self.env.company
+            else:
+                company = self[0].company_id
+            if not currency:
+                currency = company.currency_id
+            prec = currency.rounding
+            round_tax = (
+                False
+                if company.tax_calculation_rounding_method == "round_globally"
+                else True
+            )
+            if "round" in self.env.context:
+                round_tax = bool(self.env.context["round"])
+
+            if not round_tax:
+                prec *= 1e-5
+            base = price_unit * quantity
+            if self._context.get("round_base", True):
+                base = currency.round(base)
+            sign = 1
+            if currency.is_zero(base):
+                sign = -1 if fixed_multiplicator < 0 else 1
+            elif base < 0:
+                sign = -1
+            for detail in line_result.get("details", []):
+                fixed = detail.get("unitOfBasis") == "FlatAmount"
+                rate = detail["rate"] if fixed else detail["rate"] * 100
+                tax_group_name = detail.get("taxName", "").removesuffix(" TAX")
+                tax_name_display = "%s %s" % (
+                    tax_group_name,
+                    ("$ %.4g" if fixed else "%.4g%%") % round(rate, 4),
+                )
+                tax = self.get_avalara_tax(rate, doc_type, tax_name=tax_name_display)
+                for tax_item in relevant_tax_ids:
+                    if tax_item["id"] == tax.id:
+                        tax_item["amount"] = (
+                            float_round(detail["tax"], precision_rounding=prec) * sign
+                        )
+                        tax_item["base"] = float_round(
+                            sign * detail["taxableAmount"], precision_rounding=prec
+                        )
+            res["total_included"] = total_excluded + sum(
+                t["amount"] for t in res["taxes"]
+            )
         return res

--- a/account_avatax_oca/models/avalara_salestax.py
+++ b/account_avatax_oca/models/avalara_salestax.py
@@ -146,6 +146,11 @@ class AvalaraSalestax(models.Model):
         help="Uncheck the this field to show exemption fields on SO/Invoice form view. "
         "Also, it will show Tax based on shipping address button",
     )
+    breakdown_all_taxes = fields.Boolean(
+        default=False,  # option to avoid disturbing current users who do not want to change
+        help="If checked, taxes will be shown as separate detailed lines instead of "
+        "one aggregated line.",
+    )
     # TODO: add option to Display Prices with Tax Included
     # Enabled the tax inclusive flag in the GetTax Request.
 

--- a/account_avatax_oca/views/avalara_salestax_view.xml
+++ b/account_avatax_oca/views/avalara_salestax_view.xml
@@ -20,6 +20,7 @@
                             <field name="company_partner_id" />
                             <field name="disable_tax_calculation" />
                             <field name="disable_address_validation" />
+                            <field name="breakdown_all_taxes" />
                         </group>
                     </group>
                     <notebook>

--- a/account_avatax_sale_oca/models/account_tax.py
+++ b/account_avatax_sale_oca/models/account_tax.py
@@ -1,4 +1,7 @@
+import ast
+
 from odoo import models
+from odoo.tools.float_utils import float_round
 
 
 class AccountTax(models.Model):
@@ -24,7 +27,7 @@ class AccountTax(models.Model):
             partner,
             is_refund,
             handle_price_include,
-            include_caba_tags=False,
+            include_caba_tags=include_caba_tags,
             fixed_multiplicator=fixed_multiplicator,
         )
         for_avatax_object = self.env.context.get("for_avatax_object")
@@ -32,7 +35,32 @@ class AccountTax(models.Model):
             # Find the Avatax amount in the document Lines
             # Looks up the line for the current product, price_unit, and quantity
             # Note that the price_unit used must consider discount
-            avatax_ids = self.env["account.tax"].search([("is_avatax", "=", True)]).ids
+            if not self:
+                company = self.env.company
+            else:
+                company = self[0].company_id
+            if not currency:
+                currency = company.currency_id
+            prec = currency.rounding
+            round_tax = (
+                False
+                if company.tax_calculation_rounding_method == "round_globally"
+                else True
+            )
+            if "round" in self.env.context:
+                round_tax = bool(self.env.context["round"])
+
+            if not round_tax:
+                prec *= 1e-5
+            base = price_unit * quantity
+            if self._context.get("round_base", True):
+                base = currency.round(base)
+            sign = 1
+            if currency.is_zero(base):
+                sign = -1 if fixed_multiplicator < 0 else 1
+            elif base < 0:
+                sign = -1
+            avatax_ids = self.search([("is_avatax", "=", True)]).ids
             for tax_data in [x for x in res["taxes"] if x["id"] in avatax_ids]:
                 line = for_avatax_object.order_line.filtered(
                     lambda x: tax_data["id"] in x.tax_id.ids
@@ -40,7 +68,33 @@ class AccountTax(models.Model):
                     and x.product_uom_qty == quantity
                     and x.price_unit == price_unit
                 )[:1]
-                if line.tax_amt:  # Avatax Amount
-                    tax_data["amount"] = line.tax_amt
-                    res["total_included"] = res["total_excluded"] + line.tax_amt
+                response = ast.literal_eval(
+                    for_avatax_object.avatax_response_log or "{}"
+                )
+                response_lines = {
+                    int(line["lineNumber"]): line for line in response.get("lines", [])
+                }
+                doc_type = for_avatax_object._get_avatax_doc_type()
+                line_result = response_lines.get(line.id)
+                if not line_result:
+                    continue
+                for detail in line_result.get("details", []):
+                    fixed = detail.get("unitOfBasis") == "FlatAmount"
+                    rate = detail["rate"] if fixed else detail["rate"] * 100
+                    tax_group_name = detail["taxName"].removesuffix(" TAX")
+                    tax_name_display = "%s %s" % (
+                        tax_group_name,
+                        ("$ %.4g" if fixed else "%.4g%%") % round(rate, 4),
+                    )
+                    tax = self.get_avalara_tax(
+                        rate, doc_type, tax_name=tax_name_display
+                    )
+                    if tax_data["id"] == tax.id:  # Avatax Amount
+                        tax_data["amount"] = (
+                            float_round(detail["tax"], precision_rounding=prec) * sign
+                        )
+                        tax_data["base"] = float_round(
+                            sign * detail["taxableAmount"], precision_rounding=prec
+                        )
+                res["total_included"] = res["total_excluded"] + line.tax_amt
         return res

--- a/account_avatax_sale_oca/models/account_tax.py
+++ b/account_avatax_sale_oca/models/account_tax.py
@@ -35,23 +35,14 @@ class AccountTax(models.Model):
             # Find the Avatax amount in the document Lines
             # Looks up the line for the current product, price_unit, and quantity
             # Note that the price_unit used must consider discount
-            if not self:
-                company = self.env.company
-            else:
-                company = self[0].company_id
-            if not currency:
-                currency = company.currency_id
-            prec = currency.rounding
-            round_tax = (
-                False
-                if company.tax_calculation_rounding_method == "round_globally"
-                else True
-            )
+            company = self.env.company if not self else self[0].company_id
+            currency = currency or company.currency_id
+            precision = currency.rounding
+            round_tax = company.tax_calculation_rounding_method != "round_globally"
             if "round" in self.env.context:
                 round_tax = bool(self.env.context["round"])
-
             if not round_tax:
-                prec *= 1e-5
+                precision *= 1e-5
             base = price_unit * quantity
             if self._context.get("round_base", True):
                 base = currency.round(base)
@@ -61,6 +52,9 @@ class AccountTax(models.Model):
             elif base < 0:
                 sign = -1
             avatax_ids = self.search([("is_avatax", "=", True)]).ids
+            avatax_config = for_avatax_object.company_id.get_avatax_config_company()
+            if not avatax_config:
+                return res
             for tax_data in [x for x in res["taxes"] if x["id"] in avatax_ids]:
                 line = for_avatax_object.order_line.filtered(
                     lambda x: tax_data["id"] in x.tax_id.ids
@@ -68,33 +62,39 @@ class AccountTax(models.Model):
                     and x.product_uom_qty == quantity
                     and x.price_unit == price_unit
                 )[:1]
-                response = ast.literal_eval(
-                    for_avatax_object.avatax_response_log or "{}"
-                )
-                response_lines = {
-                    int(line["lineNumber"]): line for line in response.get("lines", [])
-                }
-                doc_type = for_avatax_object._get_avatax_doc_type()
-                line_result = response_lines.get(line.id)
-                if not line_result:
-                    continue
-                for detail in line_result.get("details", []):
-                    fixed = detail.get("unitOfBasis") == "FlatAmount"
-                    rate = detail["rate"] if fixed else detail["rate"] * 100
-                    tax_group_name = detail["taxName"].removesuffix(" TAX")
-                    tax_name_display = "%s %s" % (
-                        tax_group_name,
-                        ("$ %.4g" if fixed else "%.4g%%") % round(rate, 4),
+                if not avatax_config.breakdown_all_taxes and line.tax_amt:
+                    tax_data["amount"] = line.tax_amt
+                else:
+                    response = ast.literal_eval(
+                        for_avatax_object.avatax_response_log or "{}"
                     )
-                    tax = self.get_avalara_tax(
-                        rate, doc_type, tax_name=tax_name_display
-                    )
-                    if tax_data["id"] == tax.id:  # Avatax Amount
-                        tax_data["amount"] = (
-                            float_round(detail["tax"], precision_rounding=prec) * sign
+                    response_lines = {
+                        int(line["lineNumber"]): line
+                        for line in response.get("lines", [])
+                    }
+                    doc_type = for_avatax_object._get_avatax_doc_type()
+                    line_result = response_lines.get(line.id)
+                    if not line_result:
+                        continue
+                    for detail in line_result.get("details", []):
+                        fixed = detail.get("unitOfBasis") == "FlatAmount"
+                        rate = detail["rate"] if fixed else detail["rate"] * 100
+                        tax_group_name = detail["taxName"].removesuffix(" TAX")
+                        tax_name_display = "%s %s" % (
+                            tax_group_name,
+                            ("$ %.4g" if fixed else "%.4g%%") % round(rate, 4),
                         )
-                        tax_data["base"] = float_round(
-                            sign * detail["taxableAmount"], precision_rounding=prec
+                        tax = self.get_avalara_tax(
+                            rate, doc_type, tax_name=tax_name_display
                         )
+                        if tax_data["id"] == tax.id:  # Avatax Amount
+                            tax_data["amount"] = (
+                                float_round(detail["tax"], precision_rounding=precision)
+                                * sign
+                            )
+                            tax_data["base"] = float_round(
+                                sign * detail["taxableAmount"],
+                                precision_rounding=precision,
+                            )
                 res["total_included"] = res["total_excluded"] + line.tax_amt
         return res

--- a/account_avatax_sale_oca/models/sale_order.py
+++ b/account_avatax_sale_oca/models/sale_order.py
@@ -201,23 +201,27 @@ class SaleOrder(models.Model):
             tax_result_line = tax_result_lines.get(line.id)
             if not tax_result_line:
                 continue
-            # Should we check the rate with the tax amount?
-            # tax_amount = tax_result_line["taxCalculated"]
-            # rate = round(tax_amount / line.price_subtotal * 100, 2)
-            # rate = tax_result_line["rate"]
             new_taxes = Tax
-            details = tax_result_line["details"]
-            for detail in details:
-                fixed = detail.get("unitOfBasis") == "FlatAmount"
-                rate = detail["rate"] if fixed else detail["rate"] * 100
-                tax_group_name = detail["taxName"].removesuffix(" TAX")
-                tax_name_display = "%s %s" % (
-                    tax_group_name,
-                    ("$ %.4g" if fixed else "%.4g%%") % round(rate, 4),
-                )
-                tax = Tax.get_avalara_tax(rate, doc_type, tax_name=tax_name_display)
-                tax, line = self.update_tax_details(tax, line, tax_result_line)
-                new_taxes |= tax
+            if avatax_config.breakdown_all_taxes:
+                details = tax_result_line["details"]
+                for detail in details:
+                    fixed = detail.get("unitOfBasis") == "FlatAmount"
+                    rate = detail["rate"] if fixed else detail["rate"] * 100
+                    tax_group_name = detail["taxName"].removesuffix(" TAX")
+                    tax_name_display = "%s %s" % (
+                        tax_group_name,
+                        ("$ %.4g" if fixed else "%.4g%%") % round(rate, 4),
+                    )
+                    tax = Tax.get_avalara_tax(rate, doc_type, tax_name=tax_name_display)
+                    tax, line = self.update_tax_details(tax, line, tax_result_line)
+                    new_taxes |= tax
+            else:
+                taxable_amt = tax_result_line.get("taxableAmount", 0.0)
+                tax_calc_amt = tax_result_line.get("taxCalculated") or 0.0
+                if taxable_amt:
+                    rate = round((tax_calc_amt / taxable_amt) * 100, 4)
+                    tax = Tax.get_avalara_tax(rate, doc_type)
+                    new_taxes |= tax
             if new_taxes not in line.tax_id:
                 line_taxes = (
                     new_taxes

--- a/account_avatax_sale_oca/models/sale_order.py
+++ b/account_avatax_sale_oca/models/sale_order.py
@@ -90,6 +90,7 @@ class SaleOrder(models.Model):
         for order in self:
             order.tax_amount = 0
 
+    # pylint: disable=W8110
     @api.depends("order_line.price_total", "order_line.product_uom_qty", "tax_amount")
     def _compute_amounts(self):
         """
@@ -97,16 +98,13 @@ class SaleOrder(models.Model):
         Their computation needs to be overriden,
         to use the amounts returned by Avatax service, stored in specific fields.
         """
-        res = super()._compute_amounts()
-        for order in self:
-            if order.tax_amount:
-                order.update(
-                    {
-                        "amount_tax": order.tax_amount,
-                        "amount_total": order.amount_untaxed + order.tax_amount,
-                    }
-                )
-        return res
+        avatax_orders = self.filtered(
+            lambda so: so.fiscal_position_id.is_avatax and so.tax_amount
+        )
+        for order in avatax_orders:
+            order.amount_tax = order.tax_amount
+            order.amount_total = order.amount_untaxed + order.amount_tax
+        super(SaleOrder, self - avatax_orders)._compute_amounts()
 
     @api.depends("tax_on_shipping_address", "partner_id", "partner_shipping_id")
     def _compute_tax_address_id(self):
@@ -201,28 +199,33 @@ class SaleOrder(models.Model):
         tax_result_lines = {int(x["lineNumber"]): x for x in tax_result["lines"]}
         for line in self.order_line:
             tax_result_line = tax_result_lines.get(line.id)
-            if tax_result_line:
-                # Should we check the rate with the tax amount?
-                # tax_amount = tax_result_line["taxCalculated"]
-                # rate = round(tax_amount / line.price_subtotal * 100, 2)
-                # rate = tax_result_line["rate"]
-                tax_calculation = 0.0
-                if tax_result_line["taxableAmount"]:
-                    tax_calculation = (
-                        tax_result_line["taxCalculated"]
-                        / tax_result_line["taxableAmount"]
-                    )
-                rate = round(tax_calculation * 100, 4)
-                tax = Tax.get_avalara_tax(rate, doc_type)
+            if not tax_result_line:
+                continue
+            # Should we check the rate with the tax amount?
+            # tax_amount = tax_result_line["taxCalculated"]
+            # rate = round(tax_amount / line.price_subtotal * 100, 2)
+            # rate = tax_result_line["rate"]
+            new_taxes = Tax
+            details = tax_result_line["details"]
+            for detail in details:
+                fixed = detail.get("unitOfBasis") == "FlatAmount"
+                rate = detail["rate"] if fixed else detail["rate"] * 100
+                tax_group_name = detail["taxName"].removesuffix(" TAX")
+                tax_name_display = "%s %s" % (
+                    tax_group_name,
+                    ("$ %.4g" if fixed else "%.4g%%") % round(rate, 4),
+                )
+                tax = Tax.get_avalara_tax(rate, doc_type, tax_name=tax_name_display)
                 tax, line = self.update_tax_details(tax, line, tax_result_line)
-                if tax not in line.tax_id:
-                    line_taxes = (
-                        tax
-                        if avatax_config.override_line_taxes
-                        else tax | line.tax_id.filtered(lambda x: not x.is_avatax)
-                    )
-                    line.tax_id = line_taxes
-                line.tax_amt = tax_result_line["tax"]
+                new_taxes |= tax
+            if new_taxes not in line.tax_id:
+                line_taxes = (
+                    new_taxes
+                    if avatax_config.override_line_taxes
+                    else new_taxes | line.tax_id.filtered(lambda x: not x.is_avatax)
+                )
+                line.tax_id |= line_taxes
+            line.tax_amt = tax_result_line["tax"]
         self.tax_amount = tax_result.get("totalTax")
         return True
 


### PR DESCRIPTION
**Context:**

 The issue addressed in PR (`https://github.com/OCA/account-fiscal-rule/pull/371`) involves handling split tax lines from Avalara—where a single invoice line (e.g., \$100) might be taxed at multiple rates (e.g., 4% on \$75 and 4.5% on \$25). however recalculating the rate leads to incorrect rate values as the amounts involved in the recalculation have been rounded by Avalara.

**What this PR improves:** 

This PR enhances the solution with a cleaner and more maintainable approach:

* **Uses Avalara API `details` directly:** Instead of calculating an average rate or recaculate rate, this PR reads each component tax (rate, taxName) directly from the API response.
* **Creates one Odoo tax per detail:** Each tax line in the API response maps to a specific `account.tax` record in Odoo, improving traceability and avoiding ambiguity.
* **Prevents unnecessary tax creation:** Ensures tax records are generated with valid, legit names (with absolute rate) (e.g., `Local Tax [Code] 4.5%`) and prevents issues caused by auto-generating taxes with obscure rate names (e.g., `9.75**`).
* **More transparent tax totals:** Makes the resulting tax structure more aligned with Avalara’s breakdown and more user-friendly - This allows us to easily compare tax information on each line from the API response logs.

**Example from PR results and a little review of some issues**: We should pay attention to the first line

- Before PR-371 merged: if we sum all percent -> the total percentage will be <=> 7 + 2.75 + 2.25 + 0.5 = 12.5% => total taxes = 750,125 instead of 585,10
- Current state of code (after PR-371): the current code has recalculated the correct tax value for each small detail, but there are some issues with the recalculated rate value not being an absolute and valid number for tax as mentioned above.
- With this PR: Each individual rate is preserved as-is and generates clean tax lines for each line, such as image below


![image](https://github.com/user-attachments/assets/4d728c5d-af43-408f-a7c7-735fcff7d93b)
